### PR TITLE
Set feedkit spec homepage to github project.

### DIFF
--- a/feedkit.gemspec
+++ b/feedkit.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["ben@benubois.com"]
 
   spec.summary       = %q{Parse various sources into consistent format}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = "https://github.com/feedbin/feedkit"
   spec.license       = "MIT"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'


### PR DESCRIPTION
This prevents trouble with bundler > 1.9 and fixes issue #1.